### PR TITLE
Version 1.2.38

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -267,6 +267,10 @@ These roles define write or read only permissions on the various objects TrackMe
    :align: center
    :width: 1200px
 
+.. tip:: **capabilities for trackme_admin:**
+
+   - the capability ``list_settings`` is required for trackme admins that are not privileged users, to be able to run actions doing updates via the TrackMe rest endpoints
+
 Data privacy
 ------------
 

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,22 @@
 Release notes
 #############
 
+Version 1.2.38
+==============
+
+**CAUTION:**
+
+This is a new main release branch, TrackMe 1.2.x requires the deployment of the following dependencies:
+
+- Semicircle Donut Chart Viz, Splunk Base: https://splunkbase.splunk.com/app/4378
+- Splunk Machine Learning Toolkit, Splunk Base: https://splunkbase.splunk.com/app/2890
+- Splunk Timeline - Custom Visualization, Splunk Base: https://splunkbase.splunk.com/app/3120
+
+TrackMe requires a summary index (defaults to trackme_summary) and a metric index (defaults to trackme_metrics):
+https://trackme.readthedocs.io/en/latest/configuration.html
+
+- Fix - Issue #287 - Since version 1.2.37 most of interractions in the UI are made via TrackMe rest endpoints, however the capability list_settings is required for non privileged users and should be added to the trackme_admin role
+
 Version 1.2.37
 ==============
 

--- a/trackme/app.manifest
+++ b/trackme/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "trackme",
-      "version": "1.2.37"
+      "version": "1.2.38"
     },
     "author": [
       {

--- a/trackme/default/app.conf
+++ b/trackme/default/app.conf
@@ -16,4 +16,4 @@ label = TrackMe
 [launcher]
 author = Guilhem Marchand
 description = Data tracking system for Splunk
-version = 1.2.37
+version = 1.2.38

--- a/trackme/default/authorize.conf
+++ b/trackme/default/authorize.conf
@@ -13,6 +13,9 @@
 # Minimal import
 importRoles = user
 
+# This capability is required for non privileged users to be able to perform update type actions via the Rest API endpoints
+list_settings = enabled
+
 # Non admin or privileged users can inherit from this role to get the minimal level of read only permissions for TrackMe
 [role_trackme_user]
 


### PR DESCRIPTION
- Fix - Issue #287 - Since version 1.2.37 most of interractions in the UI are made via TrackMe rest endpoints, however the capability list_settings is required for non privileged users and should be added to the trackme_admin role