### PR TITLE
Version 1.2.44

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,23 @@
 Release notes
 #############
 
+Version 1.2.44
+==============
+
+**CAUTION:**
+
+This is a new main release branch, TrackMe 1.2.x requires the deployment of the following dependencies:
+
+- Semicircle Donut Chart Viz, Splunk Base: https://splunkbase.splunk.com/app/4378
+- Splunk Machine Learning Toolkit, Splunk Base: https://splunkbase.splunk.com/app/2890
+- Splunk Timeline - Custom Visualization, Splunk Base: https://splunkbase.splunk.com/app/3120
+- Splunk SA CIM - Splunk Common Information Model, Splunk Base: https://splunkbase.splunk.com/app/1621
+
+TrackMe requires a summary index (defaults to trackme_summary) and a metric index (defaults to trackme_metrics):
+https://trackme.readthedocs.io/en/latest/configuration.html
+
+- Fix Issue #310 - Alert actions - Dropdown object in Smart Status tab rendering errors
+
 Version 1.2.43
 ==============
 

--- a/trackme/app.manifest
+++ b/trackme/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "trackme",
-      "version": "1.2.43"
+      "version": "1.2.44"
     },
     "author": [
       {

--- a/trackme/default/app.conf
+++ b/trackme/default/app.conf
@@ -16,4 +16,4 @@ label = TrackMe
 [launcher]
 author = Guilhem Marchand
 description = Data tracking system for Splunk
-version = 1.2.43
+version = 1.2.44

--- a/trackme/default/data/ui/html/TrackMe.html
+++ b/trackme/default/data/ui/html/TrackMe.html
@@ -10393,7 +10393,7 @@ require([
             "sample_ratio": 1,
             "earliest_time": "$showAlertsTime.earliest$",
             "cancelOnUnload": true,
-            "search": "(index=\"_internal\" OR index=\"cim_modactions\") sourcetype=\"modular_alerts:trackme_smart_status\" search_name=\"$tk_alert_title$\" object_name=* | rename object_name as object | stats count by object | sort limit=10000 object",
+            "search": "(index=\"_internal\" OR index=\"cim_modactions\") sourcetype=\"modular_alerts:trackme_smart_status\" search_name=\"$tk_alert_title$\" object_name=* | rex \"object_name=(?<object>[^\\\"]*)\" | stats count by object | sort limit=10000 object",
             "latest_time": "$showAlertsTime.latest$",
             "status_buckets": 0,
             "app": utils.getCurrentApp(),


### PR DESCRIPTION
Version 1.2.44
==============

**CAUTION:**

This is a new main release branch, TrackMe 1.2.x requires the deployment of the following dependencies:

- Semicircle Donut Chart Viz, Splunk Base: https://splunkbase.splunk.com/app/4378
- Splunk Machine Learning Toolkit, Splunk Base: https://splunkbase.splunk.com/app/2890
- Splunk Timeline - Custom Visualization, Splunk Base: https://splunkbase.splunk.com/app/3120
- Splunk SA CIM - Splunk Common Information Model, Splunk Base: https://splunkbase.splunk.com/app/1621

TrackMe requires a summary index (defaults to trackme_summary) and a metric index (defaults to trackme_metrics):
https://trackme.readthedocs.io/en/latest/configuration.html

- Fix Issue #310 - Alert actions - Dropdown object in Smart Status tab rendering errors
