### PR TITLE
Version 1.2.50

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,23 @@
 Release notes
 #############
 
+Version 1.2.50
+==============
+
+**CAUTION:**
+
+This is a new main release branch, TrackMe 1.2.x requires the deployment of the following dependencies:
+
+- Semicircle Donut Chart Viz, Splunk Base: https://splunkbase.splunk.com/app/4378
+- Splunk Machine Learning Toolkit, Splunk Base: https://splunkbase.splunk.com/app/2890
+- Splunk Timeline - Custom Visualization, Splunk Base: https://splunkbase.splunk.com/app/3120
+- Splunk SA CIM - Splunk Common Information Model, Splunk Base: https://splunkbase.splunk.com/app/1621
+
+TrackMe requires a summary index (defaults to trackme_summary) and a metric index (defaults to trackme_metrics):
+https://trackme.readthedocs.io/en/latest/configuration.html
+
+- Fix - Issue #352 - Splunk 8.2 regression in data sampling engine causes only 1 event to be stored in the sampling KVstore post execution due stats first(*) change in behaviour
+
 Version 1.2.49
 ==============
 

--- a/trackme/app.manifest
+++ b/trackme/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "trackme",
-      "version": "1.2.49"
+      "version": "1.2.50"
     },
     "author": [
       {

--- a/trackme/default/app.conf
+++ b/trackme/default/app.conf
@@ -16,4 +16,4 @@ label = TrackMe
 [launcher]
 author = Guilhem Marchand
 description = Data tracking system for Splunk
-version = 1.2.49
+version = 1.2.50

--- a/trackme/default/macros.conf
+++ b/trackme/default/macros.conf
@@ -1811,7 +1811,7 @@ definition = eval custom_detected_format = [ | `trackme_data_sampling_custom_mod
 | eventstats dc(current_detected_format_id) as current_detected_format_dcount, max(exclusive_match_anomaly) as exclusive_match_anomaly by data_name\
 \
 `comment("##### Merge per entity #####")`\
-| stats values(raw_sample) as raw_sample, values(current_detected_format) as current_detected_format, values(current_detected_format_id) as current_detected_format_id, first(*) as "*" by data_name\
+| stats values(raw_sample) as raw_sample, values(current_detected_format) as current_detected_format, values(current_detected_format_id) as current_detected_format_id, first(current_detected_format_dcount) as current_detected_format_dcount, first(data_sourcetype) as data_sourcetype, first(exclusive_match_anomaly) as exclusive_match_anomaly, first(key) as key, first(model_type) as model_type by data_name\
 \
 `comment("##### Lookup the custom rules ")`\
 | lookup trackme_data_sampling_custom_models model_id as current_detected_format_id OUTPUT model_id as custom_rule_found\


### PR DESCRIPTION
- Fix - Issue #352 - Splunk 8.2 regression in data sampling engine causes only 1 event to be stored in the sampling KVstore post execution due stats first(*) change in behaviour
