### PR TITLE
Version 1.2.51

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -16,7 +16,8 @@ This is a new main release branch, TrackMe 1.2.x requires the deployment of the 
 TrackMe requires a summary index (defaults to trackme_summary) and a metric index (defaults to trackme_metrics):
 https://trackme.readthedocs.io/en/latest/configuration.html
 
-
+- Fix - Issue #356 - trackme.py endpoint check can be circumvented to perform REST calls to endpoints external to TrackMe
+- Fix - Issue #357 - In Splunk Cloud the UI manage and configure will not provide the right URL for quick access to the macro definition
 
 Version 1.2.50
 ==============

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,23 @@
 Release notes
 #############
 
+Version 1.2.51
+==============
+
+**CAUTION:**
+
+This is a new main release branch, TrackMe 1.2.x requires the deployment of the following dependencies:
+
+- Semicircle Donut Chart Viz, Splunk Base: https://splunkbase.splunk.com/app/4378
+- Splunk Machine Learning Toolkit, Splunk Base: https://splunkbase.splunk.com/app/2890
+- Splunk Timeline - Custom Visualization, Splunk Base: https://splunkbase.splunk.com/app/3120
+- Splunk SA CIM - Splunk Common Information Model, Splunk Base: https://splunkbase.splunk.com/app/1621
+
+TrackMe requires a summary index (defaults to trackme_summary) and a metric index (defaults to trackme_metrics):
+https://trackme.readthedocs.io/en/latest/configuration.html
+
+
+
 Version 1.2.50
 ==============
 

--- a/trackme/app.manifest
+++ b/trackme/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "trackme",
-      "version": "1.2.50"
+      "version": "1.2.51"
     },
     "author": [
       {

--- a/trackme/bin/trackme.py
+++ b/trackme/bin/trackme.py
@@ -35,7 +35,7 @@ class TrackMeRestHandler(GeneratingCommand):
 
     def generate(self, **kwargs):
 
-        if (self.url and re.search(r"services\/trackme", self.url)) and self.mode in ("get", "post", "delete"):
+        if (self.url and re.search(r"^\/services\/trackme\/v\d*", self.url)) and self.mode in ("get", "post", "delete"):
 
             # Get the session key
             session_key = self._metadata.searchinfo.session_key

--- a/trackme/default/app.conf
+++ b/trackme/default/app.conf
@@ -16,4 +16,4 @@ label = TrackMe
 [launcher]
 author = Guilhem Marchand
 description = Data tracking system for Splunk
-version = 1.2.50
+version = 1.2.51

--- a/trackme/default/data/ui/html/TrackMe_manage.html
+++ b/trackme/default/data/ui/html/TrackMe_manage.html
@@ -2364,6 +2364,7 @@ require([
         function defineRootUri() {
             var rootUri;
             var splunkVersion = $C.VERSION_LABEL.replace(".", "")
+            splunkVersion = splunkVersion.substring(0, 2);
                 if (Number(splunkVersion) >= '82') {
                     var rootUri = '/en-GB/manager/trackme/data/macros/';
                 } else {


### PR DESCRIPTION
- Fix - Issue #356 - trackme.py endpoint check can be circumvented to perform REST calls to endpoints external to TrackMe
- Fix - Issue #357 - In Splunk Cloud the UI manage and configure will not provide the right URL for quick access to the macro definition
