### PR TITLE
Version 1.2.58

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -12,6 +12,7 @@ Version 1.2.58
 
 - Fix Issue #379 - urllib3 insecure error messages from custom endpoint when interracting with splunkd
 - Fix Issue #378 - backup and restore generate POST related warning messages
+- Fix Issue #377 - Typos in sample instructions in backup and restore user interface
 
 Version 1.2.57
 ==============

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,17 @@
 Release notes
 #############
 
+Version 1.2.58
+==============
+
+.. warning:: **Splunk 8.x and Python3 support only**
+
+    - Starting from this release, only Splunk 8.x and Python3 are supported
+    - Some functions such as builtin alert actions are not compatible any longer with Python2 and Splunk 7.x
+    - For the latest version available for Splunk 7.x, see the release 1.2.51
+
+- Fix Issue #379 - urllib3 insecure error messages from custom endpoint when interracting with splunkd
+
 Version 1.2.57
 ==============
 

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -11,6 +11,7 @@ Version 1.2.58
     - For the latest version available for Splunk 7.x, see the release 1.2.51
 
 - Fix Issue #379 - urllib3 insecure error messages from custom endpoint when interracting with splunkd
+- Fix Issue #378 - backup and restore generate POST related warning messages
 
 Version 1.2.57
 ==============

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -13,6 +13,7 @@ Version 1.2.58
 - Fix Issue #379 - urllib3 insecure error messages from custom endpoint when interracting with splunkd
 - Fix Issue #378 - backup and restore generate POST related warning messages
 - Fix Issue #377 - Typos in sample instructions in backup and restore user interface
+- Fix Issue #364 - The long term tracker can impact some data sources unexpectly in some specific conditions
 
 Version 1.2.57
 ==============

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -144,7 +144,7 @@
     "meta": {
         "name": "trackme",
         "restRoot": "trackme",
-        "version": "1.2.57",
+        "version": "1.2.58",
         "displayName": "TrackMe",
         "schemaVersion": "0.0.3"
     }

--- a/package/app.manifest
+++ b/package/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "trackme",
-      "version": "1.2.57"
+      "version": "1.2.58"
     },
     "author": [
       {

--- a/package/bin/trackme.py
+++ b/package/bin/trackme.py
@@ -60,17 +60,17 @@ class TrackMeRestHandler(GeneratingCommand):
             # Get
             if self.mode in ("get"):
                 if self.body:
-                    response = requests.get(target_url, headers={'Authorization': header}, verify=False, data=json_data)
+                    response = requests.get(target_url, headers={'Authorization': header, 'Content-Type': 'application/json'}, verify=False, data=json_data)
                 else:
                     response = requests.get(target_url, headers={'Authorization': header}, verify=False)                    
 
             # Post (body is required)
             elif self.mode in ("post"):
-                response = requests.post(target_url, headers={'Authorization': header}, verify=False, data=json_data)
+                response = requests.post(target_url, headers={'Authorization': header, 'Content-Type': 'application/json'}, verify=False, data=json_data)
 
             # Delete (body is required)
             elif self.mode in ("delete"):
-                response = requests.delete(target_url, headers={'Authorization': header}, verify=False, data=json_data)
+                response = requests.delete(target_url, headers={'Authorization': header, 'Content-Type': 'application/json'}, verify=False, data=json_data)
 
             # yield data
 

--- a/package/default/app.conf
+++ b/package/default/app.conf
@@ -16,7 +16,6 @@ label = TrackMe
 [launcher]
 author = Guilhem Marchand
 description = Data tracking system for Splunk
-version = 1.2.57
 
 [triggers]
 reload.trackme_settings = simple

--- a/package/default/data/ui/views/trackMe_backup_and_restore.xml
+++ b/package/default/data/ui/views/trackMe_backup_and_restore.xml
@@ -37,7 +37,7 @@
           <i>Restore all collections from an backup archive file via REST using the trackme API command:</i>
           <br/>
           <code style="font-size: 15px; color: black;">
-          | <span style="color: blue;">trackme</span> <span style="color: green;">url</span>="/services/trackme/v1/backup_and_restore/restore" <span style="color: green;">mode</span>="post" <span style="color: green;">body</span>="{body="{'backup_archive': 'trackme-backup-20210205-142635.tgz', 'dry_run': 'false', 'target': 'all'}"
+          | <span style="color: blue;">trackme</span> <span style="color: green;">url</span>="/services/trackme/v1/backup_and_restore/restore" <span style="color: green;">mode</span>="post" <span style="color: green;">body</span>="{'backup_archive': 'trackme-backup-20210205-142635.tgz', 'dry_run': 'false', 'target': 'all'}"
           </code>
         </h2>
 
@@ -45,7 +45,7 @@
           <i>Restore a specific collection from an backup archive file via REST using the trackme API command:</i>
           <br/>
           <code style="font-size: 15px; color: black;">
-          | <span style="color: blue;">trackme</span> <span style="color: green;">url</span>="/services/trackme/v1/backup_and_restore/restore" <span style="color: green;">mode</span>="post" <span style="color: green;">body</span>="{body="{'backup_archive': 'trackme-backup-20210205-142635.tgz', 'dry_run': 'false', 'target': 'kv_trackme_data_source_monitoring.json'}"
+          | <span style="color: blue;">trackme</span> <span style="color: green;">url</span>="/services/trackme/v1/backup_and_restore/restore" <span style="color: green;">mode</span>="post" <span style="color: green;">body</span>="{'backup_archive': 'trackme-backup-20210205-142635.tgz', 'dry_run': 'false', 'target': 'kv_trackme_data_source_monitoring.json'}"
           </code>
         </h2>
 

--- a/package/default/savedsearches.conf
+++ b/package/default/savedsearches.conf
@@ -258,7 +258,7 @@ search  = | savedsearch "TrackMe - Data sources abstract root tracker"\
 `comment("#### Exclude Elastic sources which are managed by the Elastic shared tracker or dedicated Elastic trackers ####")`\
 | search NOT [ | inputlookup append=t trackme_elastic_sources | inputlookup append=t trackme_elastic_sources_dedicated | fields data_name | format | fields search ]\
 \
-| where data_last_time_seen<relative_time(now(), "-4h-5m")\
+| where ( data_last_time_seen<relative_time(now(), "-4h-5m") AND data_last_ingest<relative_time(now(), "-4h-5m") )\
 \
 `comment("#### collects latest collection state into the summary index ####")`\
 | `trackme_collect_state("current_state_tracking:data_source", "data_name")`\

--- a/package/lib/trackme_rest_handler.py
+++ b/package/lib/trackme_rest_handler.py
@@ -2,6 +2,8 @@ import os
 import re
 import sys
 import json
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 from splunk.persistconn.application import PersistentServerConnectionApplication
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version = 1.2.57
+version = 1.2.58


### PR DESCRIPTION
Version 1.2.58
==============

.. warning:: **Splunk 8.x and Python3 support only**

    - Starting from this release, only Splunk 8.x and Python3 are supported
    - Some functions such as builtin alert actions are not compatible any longer with Python2 and Splunk 7.x
    - For the latest version available for Splunk 7.x, see the release 1.2.51

- Fix Issue #379 - urllib3 insecure error messages from custom endpoint when interracting with splunkd
- Fix Issue #378 - backup and restore generate POST related warning messages
- Fix Issue #377 - Typos in sample instructions in backup and restore user interface
- Fix Issue #364 - The long term tracker can impact some data sources unexpectly in some specific conditions
