### PR TITLE
use artemrys/workflow-splunk-addon to build and check appinspect cli

### DIFF
--- a/.app-vetting.yaml
+++ b/.app-vetting.yaml
@@ -1,0 +1,2 @@
+check_indexes_conf_does_not_exist:
+  comment: 'N/A'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    uses: artemrys/workflow-splunk-addon/.github/workflows/reusable-build-release.yaml@v0.0.10

--- a/package/default/app.conf
+++ b/package/default/app.conf
@@ -16,6 +16,7 @@ label = TrackMe
 [launcher]
 author = Guilhem Marchand
 description = Data tracking system for Splunk
+version = 1.2.58
 
 [triggers]
 reload.trackme_settings = simple


### PR DESCRIPTION
This PR adds Github reusable workflow that builds, packages and runs Appinspect CLI checks.

Also, from latest [Appinspect CLI action](https://github.com/splunk/appinspect-cli-action) there is a possibility to mark some checks as expected, so that's why `.app-vetting.yaml` file was created and `check_indexes_conf_does_not_exist` was put as expected failure.

Also, added `launcher.version` to `app.conf` file to be able to get version from the workflow.